### PR TITLE
Added support for external logging domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,20 +80,15 @@
       </ol>
       <p>ToDo: implement SRI integrity check once version is stable</p>
 
-      <h2>Enabeling Logging</h2>
+      <h2>Enabling Logging</h2>
       <p>
-        In order to enable logging you will need to first deploy the logger on Cloudflare https://github.com/troyhunt/password-purgatory-logger:
+        In order to enable logging you will need to first deploy the logger on Cloudflare https://github.com/troyhunt/password-purgatory-logger.<br>
+        Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own cloudflare worker domain.
       </p>
       <code>
-        &lt;script&gt;let apiDomain = &quot;https://my-password-purgatory-logger.username.workers.dev&quot;;&lt;/script&gt;
+        &lt;script&gt;let apiDomain = &quot;https://password-purgatory-logger.jlynx.workers.dev&quot;;&lt;/script&gt;
+&lt;script src=&quot;https://password-purgatory-jlynx.pages.dev/log-hell.js&quot;&gt;&lt;/script&gt;
       </code>
-      <p>The script expects the embedding page to provide the following:</p>
-      <ol>
-        <li>A form named &quot;passwordPurgatory&quot;</li>
-        <li>A password field named &quot;password&quot;</li>
-        <li>An element for the response named &quot;response&quot;</li>
-      </ol>
-      <p>ToDo: implement SRI integrity check once version is stable</p>
 
       <h2>Source Code</h2>
       <p>

--- a/index.html
+++ b/index.html
@@ -88,8 +88,8 @@
         Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own Cloudflare worker domain.
       </p>
       <code>
-        &lt;script&gt;let apiDomain = &quot;https://password-purgatory-logger.jlynx.workers.dev&quot;;&lt;/script&gt;<br>
-&lt;script src=&quot;https://password-purgatory-jlynx.pages.dev/log-hell.js&quot;&gt;&lt;/script&gt;
+        &lt;script&gt;let apiDomain = &quot;https://my-password-purgatory-logger.my-username.workers.dev&quot;;&lt;/script&gt;<br>
+&lt;script src=&quot;https://passwordpurgatory.com/log-hell.js&quot;&gt;&lt;/script&gt;
       </code>
 
       <h2>Source Code</h2>

--- a/index.html
+++ b/index.html
@@ -80,6 +80,21 @@
       </ol>
       <p>ToDo: implement SRI integrity check once version is stable</p>
 
+      <h2>Enabeling Logging</h2>
+      <p>
+        In order to enable logging you will need to first deploy the logger on Cloudflare https://github.com/troyhunt/password-purgatory-logger:
+      </p>
+      <code>
+        &lt;script&gt;let apiDomain = &quot;https://my-password-purgatory-logger.username.workers.dev&quot;;&lt;/script&gt;
+      </code>
+      <p>The script expects the embedding page to provide the following:</p>
+      <ol>
+        <li>A form named &quot;passwordPurgatory&quot;</li>
+        <li>A password field named &quot;password&quot;</li>
+        <li>An element for the response named &quot;response&quot;</li>
+      </ol>
+      <p>ToDo: implement SRI integrity check once version is stable</p>
+
       <h2>Source Code</h2>
       <p>
         All code in Password Purgatory is open source and available on GitHub in

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own cloudflare worker domain.
       </p>
       <code>
-        &lt;script&gt;let apiDomain = &quot;https://password-purgatory-logger.jlynx.workers.dev&quot;;&lt;/script&gt;
+        &lt;script&gt;let apiDomain = &quot;https://password-purgatory-logger.jlynx.workers.dev&quot;;&lt;/script&gt;<br>
 &lt;script src=&quot;https://password-purgatory-jlynx.pages.dev/log-hell.js&quot;&gt;&lt;/script&gt;
       </code>
 

--- a/index.html
+++ b/index.html
@@ -85,10 +85,10 @@
         In order to enable logging you will need to first deploy the logger on Cloudflare <a href="https://github.com/troyhunt/password-purgatory-logger"
         >github.com/troyhunt/password-purgatory-logger</a
       >.<br>
-        Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own Cloudflare worker domain.
+        Once that is done, you will then need to include the following scripts in your code making sure to replace the logger domain with your own Cloudflare worker domain.
       </p>
       <code>
-        &lt;script&gt;let apiDomain = &quot;https://my-password-purgatory-logger.my-username.workers.dev&quot;;&lt;/script&gt;<br>
+        &lt;script&gt;let loggerDomain = &quot;https://my-password-purgatory-logger.my-username.workers.dev&quot;;&lt;/script&gt;<br>
 &lt;script src=&quot;https://passwordpurgatory.com/log-hell.js&quot;&gt;&lt;/script&gt;
       </code>
 

--- a/index.html
+++ b/index.html
@@ -82,8 +82,10 @@
 
       <h2>Enabling Logging</h2>
       <p>
-        In order to enable logging you will need to first deploy the logger on Cloudflare https://github.com/troyhunt/password-purgatory-logger.<br>
-        Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own cloudflare worker domain.
+        In order to enable logging you will need to first deploy the logger on Cloudflare <a href="https://github.com/troyhunt/password-purgatory-logger"
+        >github.com/troyhunt/password-purgatory-logger</a
+      >.<br>
+        Once that is done, you will then need to include the following scripts in your code making sure to replace the API domain with your own Cloudflare worker domain.
       </p>
       <code>
         &lt;script&gt;let apiDomain = &quot;https://password-purgatory-logger.jlynx.workers.dev&quot;;&lt;/script&gt;<br>
@@ -106,6 +108,12 @@
           The API:
           <a href="https://github.com/troyhunt/password-purgatory-api"
             >github.com/troyhunt/password-purgatory-api</a
+          >
+        </li>
+        <li>
+          The Logger:
+          <a href="https://github.com/troyhunt/password-purgatory-logger"
+            >github.com/troyhunt/password-purgatory-logger</a
           >
         </li>
       </ol>

--- a/log-hell.js
+++ b/log-hell.js
@@ -20,8 +20,9 @@ window.addEventListener("load", function () {
 
 async function logHell(kvKey, criteria, password) {
   (async () => {
+    let domain = document.currentScript.getAttribute('domain') ?? "https://api.passwordpurgatory.com"
     const rawResponse = await fetch(
-      "https://password-purgatory-logger.jlynx.workers.dev/log-hell",
+      domain + "/log-hell",
       {
         method: "POST",
         headers: {

--- a/log-hell.js
+++ b/log-hell.js
@@ -20,7 +20,9 @@ window.addEventListener("load", function () {
 
 async function logHell(kvKey, criteria, password) {
   (async () => {
-    let domain = document.currentScript.getAttribute('domain') ?? "https://api.passwordpurgatory.com"
+    console.log(document.currentScript.getAttribute('domain'));
+    let domain = document.currentScript.getAttribute('domain');
+//      let domain = document.currentScript.getAttribute('domain') ?? "https://api.passwordpurgatory.com"
     console.log(document.currentScript.getAttribute('domain'));
     console.log(domain);
     const rawResponse = await fetch(

--- a/log-hell.js
+++ b/log-hell.js
@@ -21,7 +21,7 @@ window.addEventListener("load", function () {
 async function logHell(kvKey, criteria, password) {
   (async () => {
     // Specify your own domain using the apiDomain varaible. If nothing defined, then stick to the default
-    let domain = typeof apiDomain !== 'undefined' ? apiDomain : "https://api.passwordpurgatory.com";
+    let domain = typeof loggerDomain !== 'undefined' ? loggerDomain : "https://api.passwordpurgatory.com";
     const rawResponse = await fetch(
       domain + "/log-hell",
       {

--- a/log-hell.js
+++ b/log-hell.js
@@ -21,6 +21,8 @@ window.addEventListener("load", function () {
 async function logHell(kvKey, criteria, password) {
   (async () => {
     let domain = document.currentScript.getAttribute('domain') ?? "https://api.passwordpurgatory.com"
+    console.log(document.currentScript.getAttribute('domain'));
+    console.log(domain);
     const rawResponse = await fetch(
       domain + "/log-hell",
       {

--- a/log-hell.js
+++ b/log-hell.js
@@ -21,7 +21,7 @@ window.addEventListener("load", function () {
 async function logHell(kvKey, criteria, password) {
   (async () => {
     const rawResponse = await fetch(
-      "https://api.passwordpurgatory.com/log-hell",
+      "https://password-purgatory-logger.jlynx.workers.dev/log-hell",
       {
         method: "POST",
         headers: {

--- a/log-hell.js
+++ b/log-hell.js
@@ -20,6 +20,7 @@ window.addEventListener("load", function () {
 
 async function logHell(kvKey, criteria, password) {
   (async () => {
+    // Specify your own domain using the apiDomain varaible. If nothing defined, then stick to the default
     let domain = typeof apiDomain !== 'undefined' ? apiDomain : "https://api.passwordpurgatory.com";
     const rawResponse = await fetch(
       domain + "/log-hell",

--- a/log-hell.js
+++ b/log-hell.js
@@ -20,10 +20,7 @@ window.addEventListener("load", function () {
 
 async function logHell(kvKey, criteria, password) {
   (async () => {
-    console.log(document.currentScript.getAttribute('domain'));
-    let domain = document.currentScript.getAttribute('domain');
-//      let domain = document.currentScript.getAttribute('domain') ?? "https://api.passwordpurgatory.com"
-    console.log(document.currentScript.getAttribute('domain'));
+     let domain = apiDomain ?? "https://api.passwordpurgatory.com"
     console.log(domain);
     const rawResponse = await fetch(
       domain + "/log-hell",

--- a/log-hell.js
+++ b/log-hell.js
@@ -20,8 +20,7 @@ window.addEventListener("load", function () {
 
 async function logHell(kvKey, criteria, password) {
   (async () => {
-     let domain = apiDomain ?? "https://api.passwordpurgatory.com"
-    console.log(domain);
+    let domain = typeof apiDomain !== 'undefined' ? apiDomain : "https://api.passwordpurgatory.com";
     const rawResponse = await fetch(
       domain + "/log-hell",
       {


### PR DESCRIPTION
Since in order to use the logging function of password purgatory the user needs to deploy their own Cloudflare workers, I have added the ability to specify the logger domain. I have also updated the website documentation to reflect this. You can view the example I have set up here https://password-purgatory-jlynx.pages.dev/

Please view https://github.com/troyhunt/password-purgatory-logger/pull/1 for the logger side of this PR

Please Squash and merge